### PR TITLE
Updated choosing target path

### DIFF
--- a/src/AutoMerge/Branches/BranchesViewModel.cs
+++ b/src/AutoMerge/Branches/BranchesViewModel.cs
@@ -478,7 +478,7 @@ namespace AutoMerge
 
         private static bool IsTargetPath(ItemIdentifier mergeRelations, ItemIdentifier branch)
         {
-            return mergeRelations.Item.Contains(branch.Item);
+            return mergeRelations.Item.Contains(branch.Item + "/");
         }
 
         private static string CalculateTopFolder(IList<Change> changes)


### PR DESCRIPTION
Determine target path by searching with trailing slash "/"

There is a problem when you have multiple branches with same prefix, e.g. ABC and ABCDE. When merging to ABC method choses ABCDE instead, and as a result there are multiple branches with the same name in target branch selector. I do not know if this affects merging itself, but it is confusing.

I fixed it by searching with trailing /, so ABCDE branch will not fit to Contains createria.