### PR TITLE
Prevent from check-in if policies fail

### DIFF
--- a/src/AutoMerge/Branches/BranchesViewModel.cs
+++ b/src/AutoMerge/Branches/BranchesViewModel.cs
@@ -968,6 +968,7 @@ namespace AutoMerge
             if (!CanCheckIn(evaluateCheckIn, skipPolicyValidate))
             {
                 result.CheckinResult = MergeResult.CheckInEvaluateFail;
+                return result;
             }
 
             var changesetId = workspace.CheckIn(targetPendingChanges.ToArray(), null, comment,


### PR DESCRIPTION
Hi there,

I made a small fix to prevent check-in if the evaluation of check-in policies fails. There was missing a "return" so that check-in was performed even if a policy fails.